### PR TITLE
Fix weekly submissions

### DIFF
--- a/components/weekly/form.vue
+++ b/components/weekly/form.vue
@@ -89,7 +89,7 @@ async function submit() {
   loading.value = true
   try {
     if (form.mode === CompetitionMode.REGULAR && submissionsMap.value[CompetitionMode.REGULAR]) {
-      const { data, refresh } = await useApiPost<Submission>(`/weekly/${week.value}/${submissionsMap.value[CompetitionMode.REGULAR].id}`, {
+      const { data, refresh } = await useApiPost<Submission>(`/weekly/${props.competition.alias}/${submissionsMap.value[CompetitionMode.REGULAR].id}`, {
         body: {
           comment: form.comment,
         },
@@ -106,7 +106,7 @@ async function submit() {
         if (isCanceled)
           return
       }
-      const { data, refresh } = await useApiPost<Submission>(`/weekly/${week.value}`, {
+      const { data, refresh } = await useApiPost<Submission>(`/weekly/${props.competition.alias}`, {
         body: {
           scrambleId: props.scramble.id,
           mode: form.mode,
@@ -136,7 +136,7 @@ async function turnToUnlimited() {
     const { isCanceled } = await reveal()
     if (isCanceled)
       return
-    const { data, refresh } = await useApiPost<Submission>(`/weekly/${week.value}/${submissionsMap.value[CompetitionMode.REGULAR].id}/unlimited`, {
+    const { data, refresh } = await useApiPost<Submission>(`/weekly/${props.competition.alias}/${submissionsMap.value[CompetitionMode.REGULAR].id}/unlimited`, {
       immediate: false,
     })
     await refresh()


### PR DESCRIPTION
Right now, nobody can submit results for the ongoing weekly competitions. Because the frontend tries to submit to `2023-01` (since it parses from the startTime) whereas the current competition is `2024-01`.

This should probably fix it, I haven't tested it locally yet though