### PR TITLE
fix: spoiler should be closed after submit

### DIFF
--- a/pages/practice/[userId]/[id].vue
+++ b/pages/practice/[userId]/[id].vue
@@ -108,19 +108,30 @@ bus.on(fetchData)
           <div v-if="!submissions[scramble.id]">
             {{ $t('weekly.noSolution') }}
           </div>
+          <Submissions
+            v-else-if="mySubmissions[scramble.id]?.length > 0"
+            :submissions="submissions[scramble.id]"
+            :competition="competition"
+            :scramble="scramble"
+          />
           <Spoiler
             v-else
             :spoiled="$t('weekly.solutions')"
-            :show="mySubmissions[scramble.id]?.length > 0"
+            :show="false"
           >
             <Submissions :submissions="submissions[scramble.id]" :competition="competition" :scramble="scramble" />
           </Spoiler>
         </div>
       </Tab>
       <Tab v-if="results.length > 0" :name="$t('weekly.results')" hash="results">
+        <WeeklyResults
+          v-if="competition.scrambles.every(scramble => mySubmissions[scramble.id]?.length > 0)"
+          :results="results"
+        />
         <Spoiler
+          v-else
           :spoiled="$t('weekly.results')"
-          :show="competition.scrambles.every(scramble => mySubmissions[scramble.id]?.length > 0)"
+          :show="false"
           class="my-2"
         >
           <WeeklyResults :results="results" />


### PR DESCRIPTION
试了修改 spoiler 本身，添加额外的变量来对应手工点击。结果逻辑完崩，不知道为啥

```
diff --git a/components/spoiler.vue b/components/spoiler.vue
index cc67ad3..a0be22f 100644
--- a/components/spoiler.vue
+++ b/components/spoiler.vue
@@ -6,15 +6,17 @@ const props = withDefaults(defineProps<{
   show: false,
 })
 
-const showSpoiler = ref(props.show)
+const trigger = ref(false)
+
+const showSpoiler = computed(() => { return !(props.show || trigger) })
 </script>
 
 <template>
   <div class="relative">
     <div
-      v-if="!showSpoiler"
+      v-if="showSpoiler"
       class="absolute inset-0 z-50 bg-indigo-500 text-white flex flex-col items-center justify-center cursor-pointer"
-      @click="showSpoiler = true"
+      @click="trigger = true"
     >
       <I18nT keypath="common.spoiler" tag="div" scope="global" class="flex items-center">
         <template #for>
```