### PR TITLE
Adding true single prime symbol to replaceQuote function

### DIFF
--- a/utils/if.ts
+++ b/utils/if.ts
@@ -166,7 +166,7 @@ export function applyMark(alg: string, mark: MARKS) {
 }
 
 export function replaceQuote(string: string): string {
-  return string.replace(/[‘’`]/g, '\'')
+  return string.replace(/[‘’`′]/g, '\'')
 }
 
 export function formatAlgorithm(string: string | string[], placement: number = 0) {


### PR DESCRIPTION
I've recently started using a real prime symbol in all my cube notation, but I find when I copy/paste my skeletons into Insertion Finder it doesn't like the input. This change adds a single character, the single prime unicode character, to the function that already sanitizes curly quotes and backticks in user input.