### PR TITLE
fix: tutorial WebGL lifecycle  and leave-slice 3D display

### DIFF
--- a/components/cube/3d.vue
+++ b/components/cube/3d.vue
@@ -21,6 +21,21 @@ import { BODY_COLOR, colorToHex, CUBIE_GAP, filterColor, getFaceletPositions } f
 
 import type { Axis, FrAxisKey, FrEmphasis } from '~/utils/cube'
 
+/**
+ * 3D cube renderer.
+ *
+ * WebGL context limit (browsers typically allow 8–16 active contexts):
+ * - Default mode (isStatic=false): persistent WebGL context + animation loop.
+ *   Use when the page has only one cube (analyze / practice / DR Trigger / Endless).
+ * - Static mode (isStatic=true): transparent 2D snapshot by default (no persistent WebGL);
+ *   click to temporarily activate interaction. For pages with many cubes on screen
+ *   (FR tutorial), combined with viewport release that keeps the last snapshot visible.
+ *   Single-cube pages must not use this mode.
+ *
+ * isStatic entry points:
+ * - components/fr/tutorial-cube-step.vue
+ * - components/fr/tutorial-case-card.vue (via FrCube)
+ */
 const props = withDefaults(defineProps<{
   moves?: string
   cubieCube?: {
@@ -31,10 +46,15 @@ const props = withDefaults(defineProps<{
   filter?: 'dr' | 'fr'
   frAxis?: FrAxisKey
   frEmphasis?: FrEmphasis
+  /** Static display mode; see file header. Required for multi-cube lists (tutorial). */
   isStatic?: boolean
+  /** When false (full FR), middle-layer edges are shown normally instead of dimmed. */
+  leaveSlice?: boolean
   keyboardControls?: boolean
 }>(), {
   frEmphasis: 'axis',
+  isStatic: false,
+  leaveSlice: true,
 })
 
 const cubeElement = ref<HTMLElement>()
@@ -44,9 +64,14 @@ let camera: PerspectiveCamera
 let renderer: WebGLRenderer | null = null
 let controls: OrbitControls | null = null
 let animating = false
+let sceneReady = false
+let isInViewport = false
+let visibilityObserver: IntersectionObserver | null = null
 let staticCanvas: HTMLCanvasElement | null = null
 let liveCanvas: HTMLCanvasElement | null = null
 let deactivateTimer: ReturnType<typeof setTimeout> | null = null
+let livePointerDown = false
+const awaitingRender = ref(props.isStatic)
 const cubeMeshes: Mesh[] = []
 const keyboardRotationKeys = new Set(['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'])
 const pressedKeyboardKeys = new Set<string>()
@@ -85,7 +110,7 @@ function buildFaceColors(fl: string) {
     colors[index][axis][n] = color
   }
   const frOptions = props.filter === 'fr' && props.frAxis
-    ? { axis: props.frAxis, emphasis: props.frEmphasis }
+    ? { axis: props.frAxis, emphasis: props.frEmphasis, leaveSlice: props.leaveSlice }
     : undefined
   for (const { i, x, y, z, axis, dir } of faceletPositions)
     push(x, y, z, axis, dir, colorToHex(filterColor(props.filter, fl[i], x, y, z, fl, frOptions)))
@@ -103,6 +128,23 @@ const colorConditions: [Axis, 1 | -1][] = [
 const cubePositions = [-1, 0, 1]
 
 const matCache = new Map<number, MeshStandardMaterial>()
+
+/**
+ * The tutorial page keeps dozens of static cubes in the DOM at once.
+ * Creating a WebGLRenderer per cube (even with immediate dispose) can still
+ * briefly exceed the context limit when scrolling quickly.
+ * In isStatic mode, all instances share this offscreen renderer for 2D snapshots.
+ */
+let sharedStaticRenderer: WebGLRenderer | null = null
+
+function getSharedStaticRenderer() {
+  if (!sharedStaticRenderer) {
+    const canvas = document.createElement('canvas')
+    sharedStaticRenderer = new WebGLRenderer({ antialias: true, canvas, alpha: true })
+    sharedStaticRenderer.setClearColor(0x00_00_00, 0)
+  }
+  return sharedStaticRenderer
+}
 function getMat(hex: number) {
   if (!matCache.has(hex)) {
     matCache.set(hex, new MeshStandardMaterial({
@@ -145,6 +187,7 @@ function setSize() {
 }
 
 function buildScene() {
+  cubeMeshes.length = 0
   scene = new Scene()
   camera = new PerspectiveCamera(40, 1, 1, 100)
   camera.position.set(5.5, 4.5, 5.5)
@@ -177,9 +220,67 @@ function buildScene() {
   updateMaterials()
 }
 
+function ensureStaticCanvas(dom: HTMLElement) {
+  if (!staticCanvas) {
+    staticCanvas = document.createElement('canvas')
+    staticCanvas.style.width = '100%'
+    staticCanvas.style.height = '100%'
+    staticCanvas.style.display = 'block'
+    dom.appendChild(staticCanvas)
+    staticCanvas.addEventListener('pointerdown', onStaticPointerDown)
+  }
+  return staticCanvas
+}
+
+function unbindLivePointerHandlers() {
+  if (!liveCanvas)
+    return
+  liveCanvas.removeEventListener('pointerdown', onLivePointerDown)
+  liveCanvas.removeEventListener('pointerup', onLivePointerUp)
+  liveCanvas.removeEventListener('pointercancel', onLivePointerUp)
+}
+
+function bindLivePointerHandlers() {
+  if (!liveCanvas)
+    return
+  unbindLivePointerHandlers()
+  liveCanvas.addEventListener('pointerdown', onLivePointerDown)
+  liveCanvas.addEventListener('pointerup', onLivePointerUp)
+  liveCanvas.addEventListener('pointercancel', onLivePointerUp)
+}
+
+function onLivePointerDown() {
+  livePointerDown = true
+  if (deactivateTimer) {
+    clearTimeout(deactivateTimer)
+    deactivateTimer = null
+  }
+}
+
+function onLivePointerUp(e: PointerEvent) {
+  livePointerDown = false
+  if (e.buttons === 0)
+    scheduleDeactivate()
+}
+
+function forwardPointerToLiveCanvas(e: PointerEvent) {
+  if (!liveCanvas)
+    return
+  liveCanvas.dispatchEvent(new PointerEvent(e.type, {
+    pointerId: e.pointerId,
+    bubbles: true,
+    cancelable: true,
+    clientX: e.clientX,
+    clientY: e.clientY,
+    button: e.button,
+    buttons: e.buttons,
+    pointerType: e.pointerType,
+  }))
+}
+
 function renderToStaticCanvas(target?: HTMLCanvasElement): HTMLCanvasElement {
-  const tmpCanvas = document.createElement('canvas')
-  const tmpRenderer = new WebGLRenderer({ antialias: true, canvas: tmpCanvas, alpha: true })
+  // isStatic only: writes to a 2D canvas; no persistent WebGL context
+  const tmpRenderer = getSharedStaticRenderer()
   tmpRenderer.setPixelRatio(window.devicePixelRatio)
   tmpRenderer.setSize(width.value, width.value)
   camera.aspect = 1
@@ -187,26 +288,111 @@ function renderToStaticCanvas(target?: HTMLCanvasElement): HTMLCanvasElement {
   tmpRenderer.render(scene, camera)
 
   const out = target || document.createElement('canvas')
-  out.width = tmpCanvas.width
-  out.height = tmpCanvas.height
+  out.width = tmpRenderer.domElement.width
+  out.height = tmpRenderer.domElement.height
   out.style.width = '100%'
   out.style.height = '100%'
-  const ctx = out.getContext('2d')!
-  ctx.drawImage(tmpCanvas, 0, 0)
-  tmpRenderer.dispose()
+  out.style.display = 'block'
+  const ctx = out.getContext('2d', { alpha: true })!
+  ctx.clearRect(0, 0, out.width, out.height)
+  ctx.drawImage(tmpRenderer.domElement, 0, 0)
+  awaitingRender.value = false
   return out
 }
 
-function init() {
-  const dom = cubeElement.value!
-  buildScene()
+function disposeLiveRenderer(dom?: HTMLElement | null) {
+  if (!renderer)
+    return
 
+  animating = false
+  livePointerDown = false
+  unbindLivePointerHandlers()
+  if (props.isStatic && liveCanvas && staticCanvas && dom) {
+    renderToStaticCanvas(staticCanvas)
+    dom.replaceChild(staticCanvas, liveCanvas)
+    staticCanvas.addEventListener('pointerdown', onStaticPointerDown)
+  }
+  renderer.dispose()
+  renderer = null
+  controls?.dispose()
+  controls = null
+  liveCanvas = null
+}
+
+/** isStatic only: drop scene memory; keep last transparent 2D snapshot in the DOM */
+function releaseScene() {
+  if (!props.isStatic || renderer)
+    return
+
+  clearKeyboardRotation()
+  if (deactivateTimer) {
+    clearTimeout(deactivateTimer)
+    deactivateTimer = null
+  }
+  disposeLiveRenderer(cubeElement.value)
+  cubeMeshes.length = 0
+  sceneReady = false
+}
+
+function destroyAll() {
   if (props.isStatic) {
-    staticCanvas = renderToStaticCanvas()
-    dom.appendChild(staticCanvas)
-    staticCanvas.addEventListener('pointerdown', activate)
+    releaseScene()
+    if (staticCanvas) {
+      staticCanvas.removeEventListener('pointerdown', onStaticPointerDown)
+      staticCanvas = null
+    }
   }
   else {
+    // Single-cube pages: live WebGL only, no snapshot path
+    clearKeyboardRotation()
+    if (deactivateTimer) {
+      clearTimeout(deactivateTimer)
+      deactivateTimer = null
+    }
+    if (renderer) {
+      renderer.dispose()
+      renderer = null
+    }
+    controls?.dispose()
+    controls = null
+    liveCanvas = null
+    cubeMeshes.length = 0
+    sceneReady = false
+  }
+
+  const dom = cubeElement.value
+  if (dom)
+    dom.replaceChildren()
+  awaitingRender.value = props.isStatic
+}
+
+function tryInit() {
+  if (!isInViewport || !cubeElement.value)
+    return
+  if (!props.isStatic && renderer)
+    return
+  init()
+}
+
+function init() {
+  if (!cubeElement.value || width.value === 0)
+    return
+  if (!props.isStatic && renderer)
+    return
+
+  const dom = cubeElement.value
+
+  if (!sceneReady) {
+    buildScene()
+    sceneReady = true
+  }
+
+  if (props.isStatic) {
+    // Static mode: 2D snapshot by default; click upgrades to WebGL (one active context at a time)
+    renderToStaticCanvas(ensureStaticCanvas(dom))
+  }
+  else {
+    // Default mode: single-cube pages; creates a persistent WebGL context
     liveCanvas = document.createElement('canvas')
     liveCanvas.tabIndex = -1
     liveCanvas.style.outline = 'none'
@@ -214,6 +400,7 @@ function init() {
     liveCanvas.addEventListener('touchstart', e => e.preventDefault(), { passive: false })
     dom.appendChild(liveCanvas)
     renderer = new WebGLRenderer({ antialias: true, canvas: liveCanvas, alpha: true })
+    renderer.setClearColor(0x00_00_00, 0)
     renderer.setPixelRatio(window.devicePixelRatio)
     renderer.shadowMap.enabled = false
     controls = new OrbitControls(camera, liveCanvas)
@@ -226,12 +413,20 @@ function init() {
     controls.dampingFactor = 0.12
     setSize()
     animating = true
+    awaitingRender.value = false
     render()
   }
 }
 
+function onStaticPointerDown(e: PointerEvent) {
+  if (renderer)
+    return
+  activate()
+  requestAnimationFrame(() => forwardPointerToLiveCanvas(e))
+}
+
 function activate() {
-  if (!props.isStatic || !scene || !staticCanvas)
+  if (!props.isStatic || !staticCanvas)
     return
   const dom = cubeElement.value!
   if (deactivateTimer) {
@@ -242,14 +437,19 @@ function activate() {
   if (renderer)
     return
 
+  if (!sceneReady) {
+    buildScene()
+    sceneReady = true
+  }
+
   liveCanvas = document.createElement('canvas')
   liveCanvas.tabIndex = -1
   liveCanvas.style.outline = 'none'
   liveCanvas.addEventListener('mousedown', e => e.preventDefault())
   liveCanvas.addEventListener('touchstart', e => e.preventDefault(), { passive: false })
-  dom.replaceChild(liveCanvas, staticCanvas!)
 
   renderer = new WebGLRenderer({ antialias: true, canvas: liveCanvas, alpha: true })
+  renderer.setClearColor(0x00_00_00, 0)
   renderer.setPixelRatio(window.devicePixelRatio)
   renderer.shadowMap.enabled = false
   controls = new OrbitControls(camera, liveCanvas)
@@ -262,36 +462,30 @@ function activate() {
   controls.dampingFactor = 0.12
 
   setSize()
+  renderer.render(scene, camera)
+  dom.replaceChild(liveCanvas, staticCanvas!)
   animating = true
   render()
 
-  liveCanvas.addEventListener('pointerup', scheduleDeactivate)
-  liveCanvas.addEventListener('pointerleave', scheduleDeactivate)
+  bindLivePointerHandlers()
 }
 
 function scheduleDeactivate() {
+  if (livePointerDown || !renderer)
+    return
   if (deactivateTimer)
     clearTimeout(deactivateTimer)
   deactivateTimer = setTimeout(deactivate, 1500)
 }
 
 function deactivate() {
-  if (!renderer || !props.isStatic)
+  if (livePointerDown || !renderer || !props.isStatic)
     return
   const dom = cubeElement.value
-  if (!dom)
+  if (!dom || !staticCanvas || !liveCanvas)
     return
 
-  animating = false
-  renderToStaticCanvas(staticCanvas!)
-  dom.replaceChild(staticCanvas!, liveCanvas!)
-  staticCanvas!.addEventListener('pointerdown', activate)
-
-  renderer.dispose()
-  renderer = null
-  controls?.dispose()
-  controls = null
-  liveCanvas = null
+  disposeLiveRenderer(dom)
   deactivateTimer = null
 }
 
@@ -368,14 +562,20 @@ function render() {
 }
 
 watch(
-  () => [facelet.value, props.filter, props.frAxis, props.frEmphasis] as const,
+  () => [facelet.value, props.filter, props.frAxis, props.frEmphasis, props.leaveSlice] as const,
   () => {
+    if (!sceneReady)
+      return
     updateMaterials()
     if (props.isStatic && staticCanvas && !renderer)
       renderToStaticCanvas(staticCanvas)
   },
 )
 watch(width, () => {
+  if (isInViewport)
+    tryInit()
+  if (!sceneReady)
+    return
   if (props.isStatic && staticCanvas && !renderer) {
     renderToStaticCanvas(staticCanvas)
   }
@@ -392,30 +592,40 @@ onMounted(() => {
     window.addEventListener('blur', clearKeyboardRotation)
   }
 
-  const observer = new IntersectionObserver((entries) => {
+  visibilityObserver = new IntersectionObserver((entries) => {
     entries.forEach((entry) => {
+      isInViewport = entry.isIntersecting
       if (entry.isIntersecting) {
-        init()
-        observer.disconnect()
+        tryInit()
+        // Single-cube pages: lazy-init once, then stop observing (no teardown on scroll-away)
+        if (!props.isStatic && renderer) {
+          visibilityObserver?.disconnect()
+          visibilityObserver = null
+        }
+      }
+      else if (props.isStatic && !renderer) {
+        // Multi-cube tutorial: release scene memory but keep the last 2D snapshot visible
+        releaseScene()
       }
     })
   }, { root: null })
-  observer.observe(dom)
+  visibilityObserver.observe(dom)
 })
 
 onUnmounted(() => {
-  animating = false
+  visibilityObserver?.disconnect()
+  visibilityObserver = null
   window.removeEventListener('keydown', handleKeyboardDown, { capture: true })
   window.removeEventListener('keyup', handleKeyboardUp, { capture: true })
   window.removeEventListener('blur', clearKeyboardRotation)
-  if (deactivateTimer)
-    clearTimeout(deactivateTimer)
-  if (renderer)
-    renderer.dispose()
-  controls?.dispose()
+  destroyAll()
 })
 </script>
 
 <template>
-  <div ref="cubeElement" class="max-w-xs" />
+  <div
+    ref="cubeElement"
+    class="max-w-xs aspect-square w-full relative overflow-hidden"
+    :class="{ 'opacity-40 animate-pulse': awaitingRender }"
+  />
 </template>

--- a/components/fr/analyze-panel.vue
+++ b/components/fr/analyze-panel.vue
@@ -105,6 +105,7 @@ const showCube = computed(() => analysis.value?.ok && analysis.value.isHtr)
         <FrCube
           :scramble="analysis!.scramble"
           :axis-key="activeAxis"
+          :leave-slice="leaveSlice"
         />
       </div>
 

--- a/components/fr/cube.vue
+++ b/components/fr/cube.vue
@@ -4,6 +4,12 @@ import type { FrEmphasis } from '~/utils/cube'
 import { buildCubeState } from '~/utils/fr/display'
 import type { AxisKey } from '~/utils/fr/types'
 
+/**
+ * FR cube display wrapper (shared by analyze, practice, tutorial, etc.).
+ *
+ * isStatic defaults to false: most pages have one cube and use live WebGL.
+ * Only tutorial-case-card passes is-static, because the tutorial page renders many cubes.
+ */
 const props = withDefaults(defineProps<{
   scramble: string
   axisKey: AxisKey
@@ -12,9 +18,18 @@ const props = withDefaults(defineProps<{
   emphasis?: FrEmphasis
   fullCube?: boolean
   keyboardControls?: boolean
+  /** Forwarded to Cube3d; set true for multi-cube pages (tutorial). */
+  isStatic?: boolean
+  /** When false, middle-layer edges are not dimmed (full FR / leave-slice off). */
+  leaveSlice?: boolean
+  /** Sizing classes forwarded to Cube3d root (default fits single-cube pages). */
+  cubeClass?: string
 }>(), {
   emphasis: 'axis',
   fullCube: false,
+  isStatic: false,
+  leaveSlice: true,
+  cubeClass: 'w-full max-w-xs mx-auto',
 })
 
 const cubieCube = computed(() => buildCubeState(
@@ -33,7 +48,12 @@ const cubieCube = computed(() => buildCubeState(
       :fr-axis="fullCube ? undefined : axisKey"
       :fr-emphasis="fullCube ? undefined : emphasis"
       :keyboard-controls="keyboardControls"
-      class="w-full max-w-xs mx-auto"
+      :is-static="isStatic"
+      :leave-slice="leaveSlice"
+      :class="cubeClass"
     />
+    <template #fallback>
+      <div :class="[cubeClass, 'aspect-square']" />
+    </template>
   </ClientOnly>
 </template>

--- a/components/fr/tutorial-case-card.vue
+++ b/components/fr/tutorial-case-card.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { TutorialCaseItem } from '~/utils/fr/case-data'
+import { TUTORIAL_CUBE_CLASS } from '~/utils/fr/tutorial-cube'
 
 defineProps<{
   item: TutorialCaseItem
@@ -10,20 +11,23 @@ const { tutorialCase } = useFrTrainerTutorialText()
 
 <template>
   <div class="border rounded p-3 flex flex-col sm:flex-row gap-3">
+    <!-- Tutorial case list: many cubes per page; static mode avoids WebGL context limit -->
     <FrCube
       :scramble="item.setup"
       axis-key="ud"
       emphasis="axis"
-      class="w-32 shrink-0 mx-auto sm:mx-0"
+      is-static
+      :cube-class="TUTORIAL_CUBE_CLASS"
+      class="mx-auto sm:mx-0"
     />
     <div class="flex-1 min-w-0">
       <div class="flex items-center gap-2 mb-1">
-        <span class="inline-block px-2 py-0.5 text-xs bg-indigo-100 text-indigo-700 rounded font-medium">
+        <span class="inline-block px-2 py-0.5 text-xs bg-indigo-100 text-indigo-700 dark:bg-indigo-900/50 dark:text-indigo-300 rounded font-medium">
           {{ item.label }}
         </span>
-        <span class="font-mono text-sm text-gray-700">{{ item.alg }}</span>
+        <span class="font-mono text-sm font-semibold text-indigo-600 dark:text-indigo-400">{{ item.alg }}</span>
       </div>
-      <p class="text-sm text-gray-600">
+      <p class="text-sm text-gray-600 dark:text-gray-400">
         {{ tutorialCase(item.label) }}
       </p>
     </div>

--- a/components/fr/tutorial-cube-step.vue
+++ b/components/fr/tutorial-cube-step.vue
@@ -2,6 +2,7 @@
 import type { FrEmphasis } from '~/utils/cube'
 
 import { buildCubeMoves } from '~/utils/fr/display'
+import { TUTORIAL_CUBE_CLASS } from '~/utils/fr/tutorial-cube'
 
 const props = defineProps<{
   title?: string
@@ -24,20 +25,28 @@ const moves = computed(() => {
     <p v-if="title" class="font-semibold text-sm mb-1">
       {{ title }}
     </p>
-    <p class="text-sm text-gray-600 mb-2">
+    <p class="text-sm text-gray-600 dark:text-gray-400 mb-2">
       {{ body }}
     </p>
     <div class="flex flex-col sm:flex-row gap-3 items-center">
       <ClientOnly>
+        <!--
+          Tutorial renders dozens of cubes on one page; is-static is required to avoid
+          exhausting WebGL contexts. Analyze/practice use single-cube pages, not this component.
+        -->
         <Cube3d
           :moves="moves"
           filter="fr"
           fr-axis="ud"
           :fr-emphasis="emphasis ?? 'axis'"
-          class="w-28 shrink-0"
+          is-static
+          :class="TUTORIAL_CUBE_CLASS"
         />
+        <template #fallback>
+          <div :class="[TUTORIAL_CUBE_CLASS, 'aspect-square']" />
+        </template>
       </ClientOnly>
-      <p v-if="algLabel" class="font-mono text-sm text-indigo-600">
+      <p v-if="algLabel" class="font-mono text-sm font-semibold text-indigo-600 dark:text-indigo-400">
         {{ algLabel }}
       </p>
     </div>

--- a/utils/cube.ts
+++ b/utils/cube.ts
@@ -71,7 +71,7 @@ export function filterColor(
   y: number,
   z: number,
   fl: string,
-  frOptions?: { axis: FrAxisKey, emphasis: FrEmphasis },
+  frOptions?: { axis: FrAxisKey, emphasis: FrEmphasis, leaveSlice?: boolean },
 ): string {
   if (filter === 'fr' && frOptions) {
     if (isCenter(x, y, z))
@@ -80,7 +80,7 @@ export function filterColor(
       return GRAY_COLOR
     if (frOptions.emphasis === 'edges' && isCornerCubie(x, y, z))
       return BODY_COLOR
-    if (frOptions.emphasis === 'axis' && isFrIgnoredSliceEdge(x, y, z))
+    if (frOptions.emphasis === 'axis' && frOptions.leaveSlice !== false && isFrIgnoredSliceEdge(x, y, z))
       return GRAY_COLOR
     return FACE_COLORS[face]
   }

--- a/utils/fr/tutorial-cube.ts
+++ b/utils/fr/tutorial-cube.ts
@@ -1,0 +1,2 @@
+/** Shared cube width across FR tutorial steps and case cards */
+export const TUTORIAL_CUBE_CLASS = 'w-28 shrink-0 max-w-none'


### PR DESCRIPTION
1. Fix WebGL context exhaustion on the FR tutorial page when dozens of cubes are rendered. Tutorial cubes use isStatic mode: transparent 2D snapshots by default, shared offscreen renderer, viewport-aware scene release while keeping the last snapshot visible, and live WebGL only on click.

2. FrCube cubeClass prop, dark-mode formula contrast, and ClientOnly fallbacks. 

3. Wire leaveSlice to 3D rendering: when Leave slice mode is off, middle-layer edges are no longer dimmed on the analyze panel.

---
1. 修复教程页面，同时渲染多个3D魔方导致的WebGL上下文耗尽，部分3d魔方无法展示问题。
2. 优化黑夜模式下教程公式显示。
3. 关闭ls开关时，中层棱块不再隐藏。